### PR TITLE
Return data from action (fix GH-1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,11 @@ module.exports = {
           if (stderr_field) upd[stderr_field] = eres.stderr || "";
           await table.updateRow(upd, row.id);
         }
+        const data = {};
+        data.exitcode = eres.code || 0;
+        data.stdout = eres.stdout || "";
+        data.stderr = eres.stderr || "";
+        return data;
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saltcorn/bash",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Run bash actions in Saltcorn",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Return data from action in form `{exitcode, stdout, stderr}`.
This will be returned to client if event set as API call
or can be used in other action using `await Actions.bash_foobar()`.